### PR TITLE
optimization error to security type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ package = "wasm3-sys"
 
 [dev-dependencies]
 trybuild = "1.0"
+anyhow = "1"
 
 [profile.release]
 opt-level = 3

--- a/examples/call_wasm.rs
+++ b/examples/call_wasm.rs
@@ -1,17 +1,16 @@
 use wasm3::Environment;
 use wasm3::Module;
+use anyhow::Result;
 
-fn main() {
-    let env = Environment::new().expect("Unable to create environment");
+fn main()->Result<()> {
+    let env = Environment::new()?;
     let rt = env
-        .create_runtime(1024 * 60)
-        .expect("Unable to create runtime");
-    let module = Module::parse(&env, &include_bytes!("wasm/wasm_add/wasm_add.wasm")[..])
-        .expect("Unable to parse module");
+        .create_runtime(1024 * 60)?;
+    let module = Module::parse(&env, &include_bytes!("wasm/wasm_add/wasm_add.wasm")[..])?;
 
-    let module = rt.load_module(module).expect("Unable to load module");
+    let module = rt.load_module(module)?;
     let func = module
-        .find_function::<(i64, i64), i64>("add")
-        .expect("Unable to find function");
-    println!("Wasm says that 3 + 6 is {}", func.call(3, 6).unwrap())
+        .find_function::<(i64, i64), i64>("add")?;
+    println!("Wasm says that 3 + 6 is {}", func.call(3, 6)?);
+    Ok(())
 }

--- a/examples/wasm_link.rs
+++ b/examples/wasm_link.rs
@@ -1,28 +1,28 @@
 use wasm3::Environment;
 use wasm3::Module;
+use anyhow::Result;
 
 const MILLIS: u64 = 500_000;
 
-fn main() {
-    let env = Environment::new().expect("Unable to create environment");
+fn main()->Result<()> {
+    let env = Environment::new()?;
     let rt = env
-        .create_runtime(1024 * 60)
-        .expect("Unable to create runtime");
+        .create_runtime(1024 * 60)?;
     let module = Module::parse(
         &env,
         &include_bytes!("wasm/wasm_millis_to_seconds/wasm_millis_to_seconds.wasm")[..],
-    )
-    .expect("Unable to parse module");
+    )?;
 
-    let mut module = rt.load_module(module).expect("Unable to load module");
+    let mut module = rt.load_module(module)?;
     module
-        .link_function::<(), u64>("time", "millis", millis_wrap)
-        .expect("Unable to link function");
+        .link_function::<(), u64>("time", "millis", millis_wrap)?;
+
     let func = module
-        .find_function::<(), u64>("seconds")
-        .expect("Unable to find function");
+        .find_function::<(), u64>("seconds")?;
+
     println!("{}ms in seconds is {:?}s.", MILLIS, func.call());
     assert_eq!(func.call(), Ok(MILLIS / 1000));
+    Ok(())
 }
 
 wasm3::make_func_wrapper!(millis_wrap: millis() -> u64);

--- a/examples/wasm_link_closure.rs
+++ b/examples/wasm_link_closure.rs
@@ -1,26 +1,24 @@
 use wasm3::Environment;
 use wasm3::Module;
+use anyhow::Result;
 
 const MILLIS: u64 = 500_000;
 
 fn main() {
-    let env = Environment::new().expect("Unable to create environment");
+    let env = Environment::new()?;
     let rt = env
-        .create_runtime(1024 * 60)
-        .expect("Unable to create runtime");
+        .create_runtime(1024 * 60)?;
     let module = Module::parse(
         &env,
         &include_bytes!("wasm/wasm_millis_to_seconds/wasm_millis_to_seconds.wasm")[..],
-    )
-    .expect("Unable to parse module");
+    )?;
 
     let mut module = rt.load_module(module).expect("Unable to load module");
     module
-        .link_closure("time", "millis", |_, ()| Ok(MILLIS))
-        .expect("Unable to link closure");
+        .link_closure("time", "millis", |_, ()| Ok(MILLIS))?;
     let func = module
-        .find_function::<(), u64>("seconds")
-        .expect("Unable to find function");
-    println!("{}ms in seconds is {:?}s.", MILLIS, func.call().unwrap());
+        .find_function::<(), u64>("seconds")?;
+
+    println!("{}ms in seconds is {:?}s.", MILLIS, func.call()?);
     assert_eq!(func.call(), Ok(MILLIS / 1000));
 }

--- a/examples/wasm_link_closure_trap.rs
+++ b/examples/wasm_link_closure_trap.rs
@@ -2,25 +2,23 @@ use wasm3::error::Error;
 use wasm3::error::Trap;
 use wasm3::Environment;
 use wasm3::Module;
+use anyhow::Result;
 
-fn main() {
-    let env = Environment::new().expect("Unable to create environment");
+fn main()->Result<()> {
+    let env = Environment::new()?;
     let rt = env
-        .create_runtime(1024 * 60)
-        .expect("Unable to create runtime");
+        .create_runtime(1024 * 60)?;
     let module = Module::parse(
         &env,
         &include_bytes!("wasm/wasm_millis_to_seconds/wasm_millis_to_seconds.wasm")[..],
-    )
-    .expect("Unable to parse module");
+    )?;
 
     let mut module = rt.load_module(module).expect("Unable to load module");
     module
-        .link_closure("time", "millis", |_, ()| Err::<u64, _>(Trap::Abort))
-        .expect("Unable to link closure");
+        .link_closure("time", "millis", |_, ()| Err::<u64, _>(Trap::Abort))?;
+
     let func = module
-        .find_function::<(), u64>("seconds")
-        .expect("Unable to find function");
+        .find_function::<(), u64>("seconds")?;
 
     let err = func.call().unwrap_err();
     match err {
@@ -31,4 +29,5 @@ fn main() {
             panic!("unexpected error: {}", err)
         }
     }
+    Ok(())
 }

--- a/examples/wasm_print.rs
+++ b/examples/wasm_print.rs
@@ -1,21 +1,24 @@
 use wasm3::Environment;
 use wasm3::Module;
+use anyhow::Result;
 
 #[cfg(feature = "wasi")]
-fn main() {
-    let env = Environment::new().expect("Unable to create environment");
+fn main()->Result<()> {
+    let env = Environment::new()?;
     let rt = env
-        .create_runtime(1024 * 60)
-        .expect("Unable to create runtime");
-    let module = Module::parse(&env, &include_bytes!("wasm/wasm_print/wasm_print.wasm")[..])
-        .expect("Unable to parse module");
+        .create_runtime(1024 * 60)?;
 
-    let mut module = rt.load_module(module).expect("Unable to load module");
-    module.link_wasi().expect("Failed to link wasi");
+    let module = Module::parse(&env, &include_bytes!("wasm/wasm_print/wasm_print.wasm")[..])?;
+    let mut module = rt.load_module(module)?;
+
+    module.link_wasi()?;
+
     let func = module
-        .find_function::<(), ()>("_start")
-        .expect("Unable to find function");
-    func.call().unwrap();
+        .find_function::<(), ()>("_start")?;
+
+    func.call()?;
+
+    Ok(())
 }
 
 #[cfg(not(feature = "wasi"))]


### PR DESCRIPTION
because the current error contains pointers, which makes it unsafe, it is necessary to reposition the error as a safe error, for example, for anyhow.