### PR TITLE
replace whitelist with allowlist

### DIFF
--- a/wasm3-sys/build.rs
+++ b/wasm3-sys/build.rs
@@ -40,11 +40,11 @@ fn gen_bindings() {
         .arg("--no-layout-tests")
         .arg("--default-enum-style=moduleconsts")
         .arg("--no-doc-comments")
-        .arg("--whitelist-function")
+        .arg("--allowlist-function")
         .arg(WHITELIST_REGEX_FUNCTION)
-        .arg("--whitelist-type")
+        .arg("--allowlist-type")
         .arg(WHITELIST_REGEX_TYPE)
-        .arg("--whitelist-var")
+        .arg("--allowlist-var")
         .arg(WHITELIST_REGEX_VAR)
         .arg("--no-derive-debug");
     for &ty in PRIMITIVES.iter() {


### PR DESCRIPTION
Hi, I had a windows machine somehow using bindgen 0.63 while the wasm3-sys file has it fixed to 0.59, not sure how that happened but this PR is a fix for an error that shows up on 0.63. This fix will also still work with 0.59.

context:
- bindgen 0.63 removed support for whitelist args
- bindgen 0.58 deprecated it and added the allowlist replacements