### PR TITLE
Fix `wasm3-rs` builds

### DIFF
--- a/wasm3-sys/Cargo.toml
+++ b/wasm3-sys/Cargo.toml
@@ -25,7 +25,7 @@ cc = "1"
 shlex = "0.1.1"
 
 [build-dependencies.bindgen]
-version = "0.59"
+version = "0.64"
 optional = true
 
 [package.metadata.docs.rs]

--- a/wasm3-sys/build.rs
+++ b/wasm3-sys/build.rs
@@ -65,7 +65,7 @@ fn gen_bindings() {
         ))
         .arg("-Dd_m3LogOutput=0")
         .arg("-Iwasm3/source");
-    let status = bindgen.status().expect("Unable to generate bindings");
+    let status = bindgen.status().unwrap_or_else(|error| panic!("Unable to generate bindings: {}", error.to_string()));
     if !status.success() {
         panic!("Failed to run bindgen: {:?}", status);
     }

--- a/wasm3-sys/build.rs
+++ b/wasm3-sys/build.rs
@@ -40,15 +40,15 @@ fn gen_bindings() {
         .arg("--no-layout-tests")
         .arg("--default-enum-style=moduleconsts")
         .arg("--no-doc-comments")
-        .arg("--whitelist-function")
+        .arg("--allowlist-function")
         .arg(WHITELIST_REGEX_FUNCTION)
-        .arg("--whitelist-type")
+        .arg("--allowlist-type")
         .arg(WHITELIST_REGEX_TYPE)
-        .arg("--whitelist-var")
+        .arg("--allowlist-var")
         .arg(WHITELIST_REGEX_VAR)
         .arg("--no-derive-debug");
     for &ty in PRIMITIVES.iter() {
-        bindgen.arg("--blacklist-type").arg(ty);
+        bindgen.arg("--blocklist-type").arg(ty);
     }
     bindgen
         .arg("-o")


### PR DESCRIPTION
This mainly updates `bindgen` to version `0.64` due to this problem:
https://github.com/rust-lang/rust-bindgen/issues/2312
